### PR TITLE
 Publish v18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## v18.4
+
+### Added
+- Option to ignore diagonal inputs from the D-Pad
+- Option to use the background palette 0 color (prevents screen transition flash)
+- Option to set low battery icon display behavior
+
+### Changed
+- Tuned battery thresholds for 1.2V NiMH AA's
+
+### Fixed
+- Reduce backlight flashing when power source is nearly depleted
+- Support for Kirby Tilt-n-Tumble
+- Improved Chromatic firmware version detection
+- Support streaming to Linux platforms
+
 ## v18.0
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -58,7 +58,13 @@ index 0:
 openFPGALoader --write-flash --cable gwu2x --reset <file>
 ```
 
-Here, `<file>` refers to the generated bitstream file. This file can be found at esp32t/impl/pnr/evt1_x2.fs.
+Here, `<file>` refers to the generated bitstream file. This file can be found at `esp32t/impl/pnr/evt1_x2.fs`.
+
+## Custom Modifications
+
+When modifying the RTL design, please also update the 14-bit FPGA version within [esp32t/src/rtl/BSP/system_monitor.sv] around line 362 (see `version`).
+
+This will ensure you can always using the [ModRetro Update Tool](https://modretro.com/pages/downloads#mrupdater) to restore your Chromatic to the latest official release.
 
 ## Issues
 Please submit all issues and bug reports through our [Contact Form](https://modretro.com/pages/contact).

--- a/esp32t/evt1_x2.gprj
+++ b/esp32t/evt1_x2.gprj
@@ -27,7 +27,6 @@
         <File path="src/rtl/BSP/tlv320_init.v" type="file.verilog" enable="1"/>
         <File path="src/rtl/BSP/uart/fixed_point_divider/fixed_point_divider.v" type="file.verilog" enable="1"/>
         <File path="src/rtl/BSP/uart/uart.v" type="file.verilog" enable="1"/>
-        <File path="src/rtl/BSP/uart/usb_uart_config.v" type="file.verilog" enable="1"/>
         <File path="src/rtl/BSP/uart_packet_wrapper_rx.sv" type="file.verilog" enable="1"/>
         <File path="src/rtl/BSP/uart_packet_wrapper_tx.sv" type="file.verilog" enable="1"/>
         <File path="src/rtl/BSP/vid_system_top.v" type="file.verilog" enable="1"/>

--- a/esp32t/src/rtl/EMU/CORE/gb.v
+++ b/esp32t/src/rtl/EMU/CORE/gb.v
@@ -28,6 +28,7 @@ module gb (
 
     input isGBC,
     input real_cgb_boot,
+    input paletteOff,
 
     // cartridge interface
     // can adress up to 1MB ROM
@@ -824,6 +825,7 @@ videoBypass videoBypass (
     .megaduck    ( megaduck      ),
 
     .boot_rom_en ( boot_rom_enabled ),
+    .paletteOff ( paletteOff ),
 
     .cpu_sel_reg ( sel_video_reg ),
     .cpu_sel_oam ( sel_video_oam ),

--- a/esp32t/src/rtl/EMU/CORE/videoBypass.v
+++ b/esp32t/src/rtl/EMU/CORE/videoBypass.v
@@ -29,6 +29,7 @@ module videoBypass (
     input  megaduck,
 
     input  boot_rom_en,
+    input  paletteOff,
 
     // cpu register adn oam interface
     input  cpu_sel_oam,
@@ -596,7 +597,7 @@ always @(posedge clk) begin
     end
 end
 
-assign lcd_data = 15'h7FFF;
+assign lcd_data = (isGBC_mode || ~paletteOff) ? 15'h7FFF : { bgpd[1][6:0],bgpd[0] };
 assign lcd_clkena = lcd_clk_out;
 
 endmodule

--- a/esp32t/src/rtl/EMU/cart.v
+++ b/esp32t/src/rtl/EMU/cart.v
@@ -61,6 +61,7 @@ module cart
     
     reg p1;
     reg p2;
+    reg [1:0] phiCnt;
     always@(posedge hclk)
     begin
         if(gbreset)
@@ -131,12 +132,22 @@ module cart
                     counter <= 'd0;
                 else
                     counter <= counter + 1'd1;
-            
+                                       
+                    phiCnt <= phiCnt + 1'd1;
+                
                 case(counter)
                 16'd0:
                 begin
-                    if(cpu_halt & ~cpu_stop)
-                        phi     <=   1'd1;
+                    if(cpu_halt & ~cpu_stop) begin
+                        if (~hdma_active) begin
+                           phi     <= 1'd1;
+                           phiCnt  <= 2'd0;  
+                        end else begin
+                           if (phiCnt == 2'd3) begin
+                              phi <= ~phi;
+                           end
+                        end
+                    end
                     CART_RD <=   1'd0;
                     CART_CS <=   1'd1;
                 end

--- a/esp32t/src/rtl/EMU/emu_system_top.v
+++ b/esp32t/src/rtl/EMU/emu_system_top.v
@@ -6,6 +6,9 @@ module emu_system_top
     input               pclk,
     input               reset_n,
     
+    input               paletteOff,
+    
+    input               BTN_NODIAGONAL,
     input               BTN_A,
     input               BTN_B,
     input               BTN_DPAD_DOWN,
@@ -94,10 +97,17 @@ module emu_system_top
         BTN_A_filtered <= &BTN_A_sr[SRSIZE-1:1];
         BTN_B_filtered <= &BTN_B_sr[SRSIZE-1:1];
         
-        BTN_DPAD_DOWN_filtered_dir  <= BTN_DPAD_DOWN_filtered  & ~BTN_DPAD_UP_filtered;
-        BTN_DPAD_UP_filtered_dir    <= BTN_DPAD_UP_filtered    & ~BTN_DPAD_DOWN_filtered;
-        BTN_DPAD_LEFT_filtered_dir  <= BTN_DPAD_LEFT_filtered  & ~BTN_DPAD_RIGHT_filtered;
-        BTN_DPAD_RIGHT_filtered_dir <= BTN_DPAD_RIGHT_filtered & ~BTN_DPAD_LEFT_filtered;
+        if (BTN_NODIAGONAL) begin
+            BTN_DPAD_DOWN_filtered_dir  <= BTN_DPAD_DOWN_filtered  & ~BTN_DPAD_UP_filtered & ~BTN_DPAD_LEFT_filtered_dir & ~BTN_DPAD_RIGHT_filtered_dir;
+            BTN_DPAD_UP_filtered_dir    <= BTN_DPAD_UP_filtered    & ~BTN_DPAD_DOWN_filtered & ~BTN_DPAD_LEFT_filtered_dir & ~BTN_DPAD_RIGHT_filtered_dir;
+            BTN_DPAD_LEFT_filtered_dir  <= BTN_DPAD_LEFT_filtered  & ~BTN_DPAD_RIGHT_filtered & ~BTN_DPAD_UP_filtered_dir & ~BTN_DPAD_DOWN_filtered_dir;
+            BTN_DPAD_RIGHT_filtered_dir <= BTN_DPAD_RIGHT_filtered & ~BTN_DPAD_LEFT_filtered & ~BTN_DPAD_UP_filtered_dir & ~BTN_DPAD_DOWN_filtered_dir;
+        end else begin
+            BTN_DPAD_DOWN_filtered_dir  <= BTN_DPAD_DOWN_filtered  & ~BTN_DPAD_UP_filtered;
+            BTN_DPAD_UP_filtered_dir    <= BTN_DPAD_UP_filtered    & ~BTN_DPAD_DOWN_filtered;
+            BTN_DPAD_LEFT_filtered_dir  <= BTN_DPAD_LEFT_filtered  & ~BTN_DPAD_RIGHT_filtered;
+            BTN_DPAD_RIGHT_filtered_dir <= BTN_DPAD_RIGHT_filtered & ~BTN_DPAD_LEFT_filtered;
+        end
         
     end
 
@@ -276,6 +286,7 @@ module emu_system_top
 
         .isGBC(1'd1),
         .real_cgb_boot(1'd0),
+        .paletteOff(paletteOff),
 
         // cartridge interface
         // can adress up to 1MB ROM

--- a/esp32t/src/rtl/USB/USBUVCUART/usb_video/usb_descriptor_video.v
+++ b/esp32t/src/rtl/USB/USBUVCUART/usb_video/usb_descriptor_video.v
@@ -459,7 +459,7 @@ module usb_desc #(
         descrom[DESC_CDCIF_ADDR + CDC_NOTIFY_EP_BASE + 3] <= 8'h03;// bmAttributes = 3
         descrom[DESC_CDCIF_ADDR + CDC_NOTIFY_EP_BASE + 4] <= 8'h08;// wMaxPacketSize = 8, lsb
         descrom[DESC_CDCIF_ADDR + CDC_NOTIFY_EP_BASE + 5] <= 8'h00;// wMaxPacketSize = 0, msb
-        descrom[DESC_CDCIF_ADDR + CDC_NOTIFY_EP_BASE + 6] <= 8'h01;// bInterval = 1 ms
+        descrom[DESC_CDCIF_ADDR + CDC_NOTIFY_EP_BASE + 6] <= 8'h07;// bInterval = 8 ms
 
         //----------------- CDC Class Data Interface Descriptor -----------------
         descrom[DESC_CDCIF_ADDR + CDC_CLASS_DATA_BASE + 0] <= 8'h09;// bLength = 9 bytes

--- a/esp32t/src/rtl/USB/USBUVCUART/usbuvcuart_top.v
+++ b/esp32t/src/rtl/USB/USBUVCUART/usbuvcuart_top.v
@@ -438,7 +438,8 @@ module usbuvcuart_top(
     localparam  SET_LINE_CODING = 8'h20;
     localparam  GET_LINE_CODING = 8'h21;
     localparam  SET_CONTROL_LINE_STATE = 8'h22;
-    localparam  ENDPT_UART_CONFIG =4'h0;
+    localparam  ENDPT_UART_CONFIG = 4'h0;
+    localparam  ENDPT_UART_DATA = 16'h3;
     
     reg [15:0]  s_ctl_sig;
     reg [15:0]  s_interface_num;
@@ -574,7 +575,7 @@ module usbuvcuart_top(
                                 if (bRequest == GET_LINE_CODING) 
                                     begin
                                         s_set_len[7:0] <= usb_rxdat;
-                                        if (s_interface_num == 16'd2) 
+                                        if (s_interface_num == ENDPT_UART_DATA)
                                         begin
                                             endpt0_send <= 1'd1;
                                         end
@@ -582,13 +583,14 @@ module usbuvcuart_top(
                                     else 
                                         if (bRequest == SET_CONTROL_LINE_STATE) 
                                         begin
-                                            if (s_interface_num == 16'd2) 
+                                            if (s_interface_num == ENDPT_UART_DATA)
                                             begin
                                                 s_uart1_en <= s_ctl_sig[0];
                                             end
                                         end
                         
-                            if ((bRequest == `GET_CUR)||(bRequest == `GET_DEF)) 
+                            if ((bRequest == `GET_CUR)||(bRequest == `GET_DEF)
+                               ||(bRequest == `GET_MIN)||(bRequest == `GET_MAX))
                             begin
                                 if (wIndex[7:0] == 8'h01) 
                                 begin //Video Steam Interface
@@ -611,7 +613,7 @@ module usbuvcuart_top(
                                 if (bRequest == GET_LINE_CODING) 
                                 begin
                                     s_set_len[15:8] <= usb_rxdat;
-                                    if (s_interface_num == 16'd2) 
+                                    if (s_interface_num == ENDPT_UART_DATA)
                                     begin
                                         endpt0_send <= 1'd1;
                                         endpt0_dat <= s_dte1_rate[7:0];
@@ -634,7 +636,7 @@ module usbuvcuart_top(
                         if (usb_rxval) 
                         begin
                             sub_stage <= sub_stage + 8'd1;
-                            if(s_interface_num==2)
+                            if(s_interface_num == ENDPT_UART_DATA)
                             begin
                                 if (sub_stage <= 3) 
                                     s_dte1_rate <= {usb_rxdat,s_dte1_rate[31:8]};
@@ -647,7 +649,7 @@ module usbuvcuart_top(
                                         else 
                                             if (sub_stage == 6) 
                                                 s_data1_bits <= usb_rxdat;
-                            end // end if(s_interface_num==0)
+                            end // end if(s_interface_num == ENDPT_UART_DATA)
                         end // end if(usb_rxval)
                     end // end if(usb_rxact)&&(endpt_sel_ ==ENDPT_UART_CONFIG)
                 end // end if(bRequest == SET_LINE_CODING)
@@ -669,7 +671,7 @@ module usbuvcuart_top(
 
                                     if (usb_txpop) 
                                     begin// new controller version
-                                        if(s_interface_num==2)
+                                        if(s_interface_num == ENDPT_UART_DATA)
                                         begin
                                             if (sub_stage <= 0) 
                                                 endpt0_dat <= s_dte1_rate[15:8];
@@ -690,7 +692,7 @@ module usbuvcuart_top(
                                                                     endpt0_dat <= s_data1_bits;
                                                                 else 
                                                                     endpt0_send <= 1'b0;
-                                        end // end if(s_interface_num==0)
+                                        end // end if(s_interface_num == ENDPT_UART_DATA)
                                     end // end if(usb_txpop)
                                 end //  end if(bRequest == GET_LINE_CODING)
                             end // end if(endpt0_send == 1'b1)
@@ -790,7 +792,8 @@ module usbuvcuart_top(
                         end // if (wIndex[7:0] == 8'h01) 
                     end // if(bRequest == `SET_CUR) 
                     else 
-                        if ((bRequest == `GET_CUR)||(bRequest == `GET_DEF)) 
+                        if ((bRequest == `GET_CUR)||(bRequest == `GET_DEF)
+                            ||(bRequest == `GET_MIN)||(bRequest == `GET_MAX))
                         begin
                             stage <= 8'd0;
                             if (wIndex[7:0] == 8'h01) 
@@ -891,7 +894,8 @@ module usbuvcuart_top(
                                     end
                                 end //if (wValue[15:8] == `VS_PROBE_CONTROL)                                
                             end //if (wIndex[7:0] == 8'h01) 
-                        end // if ((bRequest == `GET_CUR)||(bRequest == `GET_DEF)) 
+                        end // if ((bRequest == `GET_CUR)||(bRequest == `GET_DEF))
+                            //||(bRequest == `GET_MIN)||(bRequest == `GET_MAX))
                         else 
                         begin
                             stage <= 8'd0;

--- a/esp32t/src/top.v
+++ b/esp32t/src/top.v
@@ -247,23 +247,25 @@ module top #(parameter ISSIMU=0)
     reg LCD_EN;
     wire qMenuInit;
     wire LCD_BACKLIGHT_INIT;
-    always@(posedge gClk or posedge memrst)
-        if(memrst)
-        begin
+    always@(posedge gClk or posedge memrst) begin
+        if(memrst) begin
             LCD_EN <= 1'd0;
             LCD_EN0 <= 1'd0;
             LCD_EN1 <= 1'd0;
-        end
-        else
-            if(LCD_VSYNC&~LCD_VSYNC_r1)
-            begin
+        end else begin
+            if(LCD_VSYNC&~LCD_VSYNC_r1) begin
                 LCD_EN0 <= LCD_INIT_DONE & LCD_BACKLIGHT_INIT;
                 LCD_EN1 <= LCD_EN0;
                 LCD_EN  <= LCD_EN1;
             end
+            // synthesis translate_off
+            LCD_EN  <= 1'd1;
+            // synthesis translate_on
+        end
+    end
     
     wire [31:0] debug_system;
-    wire [13:0] system_control;
+    wire [15:0] system_control;
     wire [17:0] LCD_DB_UVC;
     wire menuDisabled;
     wire slideOutActive;
@@ -297,6 +299,7 @@ module top #(parameter ISSIMU=0)
         .colorCorrectionEnableLCD(system_control[2]),
         .colorCorrectionEnableUVC(system_control[3]),
         .voltageLow(low_battery),
+        .lowBattDispMode(system_control[14:13]),
         .showTimer(1'b0), //system_control[8]),
         .runTimer(system_control[9]),
         .resetTimer(system_control[10]),
@@ -408,6 +411,9 @@ module top #(parameter ISSIMU=0)
         .pclk(pClk),
         .reset_n(~memrst),//lock_o),
         
+        .paletteOff(system_control[12]),
+        
+        .BTN_NODIAGONAL(system_control[11]),
         .BTN_A(BTN_A),
         .BTN_B(BTN_B),
         .BTN_DPAD_DOWN(BTN_DPAD_DOWN),
@@ -438,7 +444,6 @@ module top #(parameter ISSIMU=0)
         .lcd_on_int(lcd_on_int),
         .lcd_off_overwrite(lcd_off_overwrite),
 
-        
         .boot_rom_enabled(boot_rom_enabled),
         
         // audio


### PR DESCRIPTION
## v18.4

### Added
- Option to ignore diagonal inputs from the D-Pad
- Option to use the background palette 0 color (prevents screen transition flash)
- Option to set low battery icon display behavior

### Changed
- Tuned battery thresholds for 1.2V NiMH AA's

### Fixed
- Reduce backlight flashing when power source is nearly depleted
- Support for Kirby Tilt-n-Tumble
- Improved Chromatic firmware version detection
- Support streaming t